### PR TITLE
[pi-agent] Add a GET /api/ping endpoint that returns { "pong": true }

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,10 @@ export async function createApp(): Promise<express.Express> {
     res.json({ status: 'ok', uptime: process.uptime() });
   });
 
+  app.get('/api/ping', (_req, res) => {
+    res.json({ pong: true });
+  });
+
   app.get('/api/products', (_req, res) => {
     res.json([
       { id: 1, name: 'Basic Plan', description: 'Get started with auto-chatter.', price: 9.99 },

--- a/tests/server.test.mjs
+++ b/tests/server.test.mjs
@@ -69,6 +69,14 @@ describe('web server', () => {
     }
   });
 
+  it('GET /api/ping returns 200 with { pong: true }', async () => {
+    const res = await fetch(`${baseUrl}/api/ping`);
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('content-type'), /application\/json/);
+    const body = await res.json();
+    assert.deepEqual(body, { pong: true });
+  });
+
   it('GET /unknown returns HTML (SPA fallback)', async () => {
     const res = await fetch(`${baseUrl}/unknown`);
     assert.equal(res.status, 200);


### PR DESCRIPTION
Closes #14

# Summary: Add GET /api/ping endpoint

## What changed and why
Added a `GET /api/ping` endpoint to `src/server.ts` that returns `{ "pong": true }` with a 200 status, as requested in issue #14.

## How it works
A new Express route handler is registered before the existing `/api/products` route. It simply responds with `res.json({ pong: true })`. No existing endpoints were modified.

## Tests written
Added one test in `tests/server.test.mjs`:
- **`GET /api/ping returns 200 with { pong: true }`** — verifies the status code is 200, the content-type is JSON, and the response body is exactly `{ pong: true }`.

All 21 unit tests and 13 e2e tests pass.

## Decisions
- Placed the route before `/api/products` to keep API routes grouped together, following the existing pattern.
- No refactoring needed — the change is minimal and self-contained.


---
_Generated by [pi coding agent](https://github.com/badlogic/pi-mono)_